### PR TITLE
Tweak path to clean-shutdown setup script - ALSO PLEASE SEE NOTE

### DIFF
--- a/scripts/pi-setup.sh
+++ b/scripts/pi-setup.sh
@@ -107,7 +107,7 @@ read -p "Are you using/planning a LipoShim to safely power down the pi if you ge
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    curl https://github.com/dexdan/clean-shutdown/raw/master/zerolipo_omnipy | bash
+    curl https://raw.githubusercontent.com/dexdan/clean-shutdown/master/zerolipo_omnipy | bash
 fi
 
 echo


### PR DESCRIPTION
Just checking that this is all working. Unfortunately initial version gave a web direct but this amend should work.
HOWEVER, just checked a call to ./omni.py shutdown and it didn't shutdown the system (with no active pod): 


pi@raspberrypi:~/omnipy $ ./omni.py shutdown
{
    "api": {
        "version_major": 1,
        "version_minor": 1
    },
    "datetime": 1552771925.332798,
    "response": {},
    "status": {},
    "success": false
}

.... it does need to please! Could this be fixed? Many thanks -- Dan