### PR TITLE
Archive omnipy.log on new pod

### DIFF
--- a/restapi.py
+++ b/restapi.py
@@ -71,6 +71,8 @@ def archive_pod():
             os.rename(POD_FILE + POD_FILE_SUFFIX, POD_FILE + archive_suffix + POD_FILE_SUFFIX)
         if os.path.isfile(POD_FILE + POD_LOG_SUFFIX):
             os.rename(POD_FILE + POD_LOG_SUFFIX, POD_FILE + archive_suffix + POD_LOG_SUFFIX)
+        if os.path.isfile(OMNIPY_LOGFILE_PREFIX + OMNIPY_LOGFILE_SUFFIX):
+            os.rename(OMNIPY_LOGFILE_PREFIX + OMNIPY_LOGFILE_SUFFIX, OMNIPY_LOGFILE_PREFIX + archive_suffix + OMNIPY_LOGFILE_SUFFIX)    
     except:
         logger.exception("Error while archiving existing pod")
 


### PR DESCRIPTION
To be merged alongside dexdan-patch-3 to archive omnipy.log (with date) when new pod started.