### PR TITLE
Flush omnipy.log before archive

### DIFF
--- a/restapi.py
+++ b/restapi.py
@@ -71,6 +71,9 @@ def archive_pod():
             os.rename(POD_FILE + POD_FILE_SUFFIX, POD_FILE + archive_suffix + POD_FILE_SUFFIX)
         if os.path.isfile(POD_FILE + POD_LOG_SUFFIX):
             os.rename(POD_FILE + POD_LOG_SUFFIX, POD_FILE + archive_suffix + POD_LOG_SUFFIX)
+        if os.path.isfile(OMNIPY_LOGFILE_PREFIX + OMNIPY_LOGFILE_SUFFIX):
+            mh.flush()
+            os.rename(OMNIPY_LOGFILE_PREFIX + OMNIPY_LOGFILE_SUFFIX, OMNIPY_LOGFILE_PREFIX + archive_suffix + OMNIPY_LOGFILE_SUFFIX)    
     except:
         logger.exception("Error while archiving existing pod")
 


### PR DESCRIPTION
As per this message on slack. New line 75. I _think_ this should work, but I've not tested it (and not sure how best to test it?....)
---
Dan Evans
@winemug - Thanks for accepting my various pr. On the log archiving issue, sure you are right re needing to flush buffered contents of logs. Looking at https://docs.python.org/3.1/library/logging.html#logging.handlers.MemoryHandler
it looks like we need flush() to flush logs from memory buffer to the (file) target as part of logging.handlers.MemoryHandler. I'll see if I can work out how to implement that into restapi.py later. (Slightly at the edge of my abilities on this tbh, but that never stopped me before!)
Posted in #omnipy-devMar 28thView message