### PR TITLE
Stop setup script saying omnipy already installed

### DIFF
--- a/scripts/pi-setup.sh
+++ b/scripts/pi-setup.sh
@@ -7,7 +7,9 @@ echo Welcome to ${bold}omnipy${normal} installation script
 echo This script will aid you in configuring your raspberry pi to run omnipy
 echo
 
-if [[ -d /home/pi/omnipy ]]
+#if [[ -d /home/pi/omnipy ]]
+OmniServiceCheck=$( systemctl | grep omnipy )
+if [[ -n $OmniServiceCheck  ]]
 then
 
 echo


### PR DESCRIPTION
... when it isn't. This PR amends the check on the omnipy existence, by changing the check from looking at existence of the directory (which the prior git clone will have already created) to checking the existence of an omnipy running service. 

This PR responds to this issue identified in slack:
almac
Finally got a pi zero that works, first one seemed to be flashed with a wrong revision.  When running the scripts to install Omnipy it says that it is already installed, do you want to reinstall it.  I can only assume this is a minor bug in the script and they arent shipping Raspbian Lite with Omnipy preloaded (well not yet anyway:grin:). Minor issue just thought I would update
Posted in #omnipyYesterday at 1:19 PMView message

1 reply

Dan Evans   [< 1 minute ago]
Yeah, I think the way the install script checks for already-installed isn't robust. (It is checking for the existence of the omnipy directory, but that will be there as a result of the user doing a git clone beforehand). I'm proposing a fix in a PR.