### PR TITLE
create data path - if it doesn't exist - before creating log file handler because it will fail otherwise. 

### DIFF
--- a/podcomm/definitions.py
+++ b/podcomm/definitions.py
@@ -67,6 +67,7 @@ def getLogger(with_console=False):
         logger.setLevel(logging.DEBUG)
         formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
 
+        os.makedirs(DATA_PATH, exist_ok=True)
         fh = logging.FileHandler(DATA_PATH + OMNIPY_LOGFILE + LOGFILE_SUFFIX)
         fh.setLevel(logging.DEBUG)
         fh.setFormatter(formatter)


### PR DESCRIPTION
logging.FileHandler won't create the directory if it doesn't exists. It will only create the file if the directory exists, but the file doesn't.

I encountered this when trying to run `python3 ~/omnipy/verify_rl.py` after installing omnipy.
The error was 
```
pi@raspberrypi:~ $ python3 ~/omnipy/verify_rl.py
Traceback (most recent call last):
  File "/home/pi/omnipy/verify_rl.py", line 7, in <module>
    logger = getLogger()
  File "/home/pi/omnipy/podcomm/definitions.py", line 58, in getLogger
    fh = logging.FileHandler(OMNIPY_LOGFILE)
  File "/usr/lib/python3.5/logging/__init__.py", line 1009, in __init__
    StreamHandler.__init__(self, self._open())
  File "/usr/lib/python3.5/logging/__init__.py", line 1038, in _open
    return open(self.baseFilename, self.mode, encoding=self.encoding)
FileNotFoundError: [Errno 2] No such file or directory: '/home/pi/data/omnipy.log'
```